### PR TITLE
Disambiguate image reference in devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
   See: https://hub.docker.com/r/mathworks/matlab for available images.
   */
   "name": "Built using MathWorks Docker Hub Image",
-  "image": "mathworks/matlab:latest",
+  "image": "docker.io/mathworks/matlab:latest",
   "onCreateCommand": {
     "install-dependencies": "sudo apt-get update && sudo apt-get install --no-install-recommends -y git"
   },


### PR DESCRIPTION
Devcontainer creation fails with a Docker-compliant CLI when multiple registries are available. Disambiguating the image reference solves the issue, and maintains compatibility with Docker itself.